### PR TITLE
refactor: security filter 규칙 변경

### DIFF
--- a/src/main/java/com/playlist/cassette/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/playlist/cassette/config/security/WebSecurityConfig.java
@@ -5,9 +5,9 @@ import com.playlist.cassette.config.security.jwt.JwtTokenFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -31,16 +31,9 @@ public class WebSecurityConfig {
             "/swagger-ui/**",
             "/callback",
             "/api/v1/track",
-            "/api/v1/tape/{uuid}/guest"
     };
-    private static final String[] AUTH_CONFIRM_LIST = {
-            "/api/v1/track/{id}",
-            "/api/v1/track/download/{id}",
-            "/api/v1/member/**",
-            "/api/v1/tape",
-            "/api/v1/tape/{id}",
-            "/api/v1/tape/download/{id}",
-            "/api/v1/auth/**"
+    private static final String[] AUTH_GET_WHITELIST = {
+            "/api/v1/tape/{id}"
     };
 
     @Bean
@@ -60,8 +53,9 @@ public class WebSecurityConfig {
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .authorizeHttpRequests()
-                .requestMatchers(AUTH_CONFIRM_LIST).authenticated()
                 .requestMatchers(AUTH_WHITELIST).permitAll()
+                .requestMatchers(HttpMethod.GET, AUTH_GET_WHITELIST).permitAll()
+                .anyRequest().authenticated()
                 .and()
                 .build(); // 권한 설정
     }

--- a/src/main/java/com/playlist/cassette/controller/TapeController.java
+++ b/src/main/java/com/playlist/cassette/controller/TapeController.java
@@ -27,8 +27,8 @@ public class TapeController {
         return ResponseHandler.generateResponse(HttpStatus.OK, tape);
     }
 
-    @GetMapping("/{uuid}/guest")
-    public ResponseEntity<Object> getTape(@PathVariable("uuid") String tapeLink) {
+    @GetMapping("/{id}")
+    public ResponseEntity<Object> getTape(@PathVariable("id") String tapeLink) {
         TapeGuestResponseDto tape = tapeService.getTape(tapeLink);
         return ResponseHandler.generateResponse(HttpStatus.OK, tape);
     }


### PR DESCRIPTION
테이프 조회 API의 엔드포인트가 `GET /api/v1/tape/{uuid}`에서 `GET /api/v1/tape/{uuid}/guest`로 바뀌었던데,
혹시 메서드 별로 필터 규칙을 적용하는 문제 때문에 그랬던 거라면 이 PR대로 바꾸면 될 거예요
만약 이거랑 별개로 그냥 `/guest`가 붙이고 싶었던 거라면 조용히 close해도 됩니당..

그리고 접근할 수 있어야 하는 곳에 접근을 못 하는 것보다, 접근할 수 없어야 하는 곳에 접근하게 되는 게 더 큰 문제라 생각해서
접근시 토큰 검증해야하는 엔드포인트들을 명시하는 방법에서, 검증 없이 접근할 수 있다고 명시하지 않은 경우를 모두 토큰 검증하도록 바꾸어봤어요.