### PR TITLE
feat: refresh token

### DIFF
--- a/src/main/java/com/playlist/cassette/service/AuthService.java
+++ b/src/main/java/com/playlist/cassette/service/AuthService.java
@@ -73,6 +73,7 @@ public class AuthService {
                 TokenDto newRefreshToken = jwtTokenProvider.generateRefreshToken(authentication);
                 member.updateRefreshToken(newRefreshToken);
                 memberRepository.save(member);
+                removeRefreshTokenInCookie(response, token);
                 setCookieWithRefreshToken(response, newRefreshToken);
             }
         } else if(jwtValidationType.equals(JwtValidationType.EXPIRED_JWT_TOKEN)) {
@@ -100,12 +101,11 @@ public class AuthService {
     }
 
     private void setCookieWithRefreshToken(HttpServletResponse response, TokenDto refreshToken) {
-
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken.getValue())
                 .path("/")
                 .secure(true)
                 .httpOnly(true)
-                .domain("12playlist.com")
+//                .domain("12playlist.com")
                 .maxAge(14*24*60*60)
                 .build();
 


### PR DESCRIPTION
refreshToken이 expiration time의 절반보다 초과될 경우 refresh 해줄 때 기존 cookie의 refreshToken을 삭제하고 갱신하는 로직 추가